### PR TITLE
feat/add removable-media plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -85,6 +85,7 @@ apps:
       - password-manager-service
       - unity7
       - wayland
+      - removable-media
     #  - etc-nextcloud
     
 build-packages:


### PR DESCRIPTION
To allow the snap to sync with local folders in the /mnt directory, the plug "removable-media" is needed.

This PR adds this plug. I've tested it by building the snap locally, and it works.